### PR TITLE
Update README for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ This repository contains a small FastAPI service that demonstrates basic CRUD op
    ```
 4. Open `http://localhost:8000` to view the sample chat UI.
 
+## Running with Docker
+You can also start the service using Docker Compose, which sets up the
+application, a Postgres database and the mock API all at once:
+
+```bash
+docker compose up --build
+```
+
+After the containers start, open `http://localhost:8000` to use the service.
+
 ## Documentation
 - [Architecture Overview](docs/architecture.md)
 - [API Reference](docs/api_reference.md)


### PR DESCRIPTION
## Summary
- document how to run the project using Docker Compose

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684f58fdecdc833193a56fcdfb177e1f