### PR TITLE
Improve docs and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,20 @@
 # AI Service
 
-This repository contains a small FastAPI service that demonstrates basic CRUD operations and a chat webhook backed by a simple intent detection model.
+A small FastAPI project featuring CRUD APIs and a chat webhook.
 
-## Features
-- REST endpoints for managing users, products and orders
-- Chat endpoint that uses Hugging Face to detect intent
-- SQLAlchemy models with optional Supabase/PostgreSQL backend
-- Minimal web interface in `static/index.html`
+## Quick start
 
-## Getting Started
-1. Clone the repository and install dependencies:
+1. Install dependencies
    ```bash
    pip install -r requirements.txt
    ```
-2. Configure your environment variables. See [Environment Configuration](docs/environment.md).
-3. Run the application:
+2. Run the app
    ```bash
    uvicorn app.main:app --reload
    ```
-4. Open `http://localhost:8000` to view the sample chat UI.
+3. Open `http://localhost:8000` for the demo UI.
 
-## Running with Docker
-You can also start the service using Docker Compose, which sets up the
-application, a Postgres database and the mock API all at once:
+Use `docker compose up --build` to start with Docker.
 
-```bash
-docker compose up --build
-```
+See the [docs](docs/) directory for full documentation.
 
-After the containers start, open `http://localhost:8000` to use the service.
-
-## Documentation
-- [Architecture Overview](docs/architecture.md)
-- [API Reference](docs/api_reference.md)
-- [Environment Configuration](docs/environment.md)
-- [Running Tests](docs/running_tests.md)
-
-Additional steps for connecting to Supabase can be found in `setup_supabase_steps.txt`.
-
-## Running Tests
-Follow the instructions in [Running Tests](docs/running_tests.md) to execute the unit tests.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,24 +1,48 @@
 # API Reference
 
 ## Users
-- `GET /users` – List all users
-- `POST /users` – Create a new user
-
-## Products
-- `GET /products` – List all products
-- `POST /products` – Create a new product
-
-## Orders
-- `GET /orders` – List all orders
-- `GET /orders/{order_id}` – Retrieve a single order
-- `POST /orders` – Create an order
-
-## Chat Webhook
-- `POST /webhook` – Main interaction endpoint used by the sample chat client. Payload:
+- `GET /users` – list all users
+- `POST /users` – create a user
   ```json
   {
-    "user_id": "string",
-    "message": "string"
+    "user_id": "u1",
+    "name": "Jane",
+    "email": "jane@example.com"
   }
   ```
-  Returns `{ "response": "..." }` with the assistant reply.
+
+## Products
+- `GET /products` – list all products
+- `POST /products` – create a product
+  ```json
+  {
+    "product_id": "p1",
+    "name": "Widget",
+    "price": 10,
+    "description": "Small widget"
+  }
+  ```
+
+## Orders
+- `GET /orders` – list all orders
+- `GET /orders/{order_id}` – get one order
+- `POST /orders` – create an order
+  ```json
+  {
+    "order_id": "o1",
+    "user_id": "u1",
+    "product_id": "p1",
+    "quantity": 1,
+    "status": "pending"
+  }
+  ```
+
+## Chat Webhook
+- `POST /webhook` – send a message to the assistant
+  ```json
+  {
+    "user_id": "u1",
+    "message": "hello"
+  }
+  ```
+  Returns `{ "response": "..." }`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,17 +1,18 @@
 # Architecture Overview
 
-This service is built with **FastAPI** and uses **SQLAlchemy** for ORM access. In development it connects to a local PostgreSQL database. In production you can point it to Supabase or another Postgres-compatible database.
+The service is built with **FastAPI** and uses **SQLAlchemy** to talk to a PostgreSQL or Supabase database. Incoming requests go through the API routers which call small service modules and persist data through SQLAlchemy models.
 
 ```
-client --HTTP--> FastAPI app --SQLAlchemy--> PostgreSQL/Supabase
+client -> FastAPI -> services -> database
 ```
 
-The main components are:
+Main packages:
 
-- **app/main.py** – FastAPI application entry point
-- **app/routes/** – Modular API routers for users, products and orders
-- **app/ai/** – Contains the intent detection helper using Hugging Face
-- **app/models/** – SQLAlchemy models
-- **app/db/** – Database session and Supabase client utilities
+- **app/main.py** – application setup and route registration
+- **app/routes/** – routers for users, products, orders and the chat webhook
+- **app/services/** – business logic and conversation handling
+- **app/models/** – SQLAlchemy models defining the tables
+- **app/ai/** – wraps the Hugging Face intent detection
+- **app/db/** – database session utilities
 
-There is also a minimal HTML client in `static/index.html` used to interact with the `/webhook` endpoint.
+Static files in `static/` provide a basic chat UI that posts messages to `/webhook`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,11 @@
+# Deployment
+
+Use Docker Compose to run the app with a local database and the mock API:
+
+```bash
+docker compose up --build
+```
+
+This starts the FastAPI service, Postgres and a small mock API. Browse to `http://localhost:8000` after the containers finish starting.
+
+For production, build the image and supply your own Postgres or Supabase database.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,14 +1,14 @@
 # Environment Configuration
 
-Configuration is managed with environment variables. Create a `.env` file in the project root or set these variables in your deployment environment.
+Create a `.env` file in the project root or export these variables:
 
-Required variables:
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `ENV` | `development` or `production` | `development` |
+| `POSTGRES_DATABASE_URL` | local PostgreSQL connection | `postgresql://postgres:postgres@localhost:5432/postgres` |
+| `DATABASE_URL` | overrides other URLs when set | *(unset)* |
+| `SUPABASE_URL` / `SUPABASE_KEY` | Supabase credentials | *(unset)* |
+| `SUPABASE_DATABASE_URL` | Supabase database connection | *(unset)* |
+| `HF_API_TOKEN` | Hugging Face token for intent detection | *(unset)* |
 
-- `ENV` – set to `development` or `production` (default: `development`)
-- `POSTGRES_DATABASE_URL` – connection string for local PostgreSQL
-- `DATABASE_URL` – overrides other database URLs when set (useful on platforms like Vercel)
-- `SUPABASE_URL` and `SUPABASE_KEY` – Supabase project credentials
-- `SUPABASE_DATABASE_URL` – connection string to the Supabase database
-- `HF_API_TOKEN` – Hugging Face API token used for intent detection
-
-See `setup_supabase_steps.txt` for detailed instructions on connecting to Supabase.
+See `setup_supabase_steps.txt` for details on connecting to Supabase.

--- a/docs/running_tests.md
+++ b/docs/running_tests.md
@@ -1,18 +1,11 @@
 # Running Tests
 
-The project uses **pytest**. Tests are located in the `tests/` directory.
+Tests use **pytest** and reside in the `tests/` folder.
 
-Create a virtual environment and install dependencies:
+1. Install the dependencies from `requirements.txt`.
+2. Run the suite:
+   ```bash
+   pytest
+   ```
 
-```bash
-pip install -r requirements.txt
-pip install pytest
-```
-
-Run all tests:
-
-```bash
-pytest
-```
-
-Some tests that require Supabase credentials will be skipped automatically if the credentials are not configured.
+Tests that require Supabase credentials are skipped automatically when the variables are missing.


### PR DESCRIPTION
## Summary
- rewrite README with a short quick start guide
- expand documentation with more details
- document environment variables in a table
- add deployment instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684f9350454483318485c9a57f40bfd2